### PR TITLE
Fix language switcher and hero button text

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -41,11 +41,11 @@ const HeroSection = () => {
         
         <div className="flex flex-col sm:flex-row gap-4 justify-center items-center mb-8 fade-in-up-delay-3">
           <Button className="bg-primary text-primary-foreground hover:bg-primary/90 px-8 py-4 text-lg font-semibold group">
-            <span>{t('heroButtonPrimary')}</span>
+            <span>{t('ctaPrimary')}</span>
             <ArrowRight className="ltr:ml-2 rtl:mr-2 h-5 w-5 transition-transform group-hover:ltr:translate-x-1 group-hover:rtl:-translate-x-1" />
           </Button>
           <Button variant="outline" className="border-primary text-primary hover:bg-primary hover:text-primary-foreground px-8 py-4 text-lg">
-            <span>{t('heroButtonSecondary')}</span>
+            <span>{t('ctaSecondary')}</span>
           </Button>
         </div>
         

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -14,7 +14,7 @@ export default function LanguageSwitcher() {
       className="flex items-center gap-2 border-primary/30 text-primary hover:bg-primary hover:text-primary-foreground"
     >
       <Globe className="h-4 w-4" />
-      <span>{currentLanguage === 'ar' ? 'العربية' : 'English'}</span>
+      <span>{currentLanguage === 'en' ? 'العربية' : 'English'}</span>
     </Button>
   );
 }


### PR DESCRIPTION
- The language switcher button now shows the language to switch to, instead of the current language.
- The hero section buttons now use the correct translation keys (`ctaPrimary` and `secondaryCta`) to display the button text.